### PR TITLE
Backfill missing lab metadata (13 files)

### DIFF
--- a/Instructions/Labs/LAB[MB-240]_Lab00_Dynamics_365_Labs.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab00_Dynamics_365_Labs.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment (5 minutes)'
-    module: 'Module 0: Course introduction'
+  title: 'Lab 0: Validate lab environment (5 minutes)'
+  module: 'Module 0: Course introduction'
+  description: Contoso Coffee produces high-quality coffee and coffee machines. They
+    sell their products through retail channels including new Contoso retail stores
+    in premium locations, premium food resellers and the Contoso Coffee website. Even
+    though their products are sold through different channels, they have certified
+    technicians that either work directly for Contoso Coffee, or that work for authorized
+    service providers who they use to provide service on machines.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab - Validate lab environment

--- a/Instructions/Labs/LAB[MB-240]_Lab01_Configure_Field_Service.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab01_Configure_Field_Service.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Lab 1: Configure Field Service (10 minutes)'
-    module: 'Module 1: Configure Field Service'
+  title: 'Lab 1: Configure Field Service (10 minutes)'
+  module: 'Module 1: Configure Field Service'
+  description: Contoso Coffee produces high-quality coffee and coffee machines. Their
+    products are sold through retail channels including new Contoso retail stores
+    in premium locations, premium food resellers and the Contoso Coffee Web Site.
+    Even though their products are sold through different channels, they have certified
+    technicians that either work directly for Contoso Coffee, or that work for authorized
+    service providers.
+  duration: 10 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Field Service
 ---
 
 # Practice Lab 1 - Configure Dynamics 365 Field Service

--- a/Instructions/Labs/LAB[MB-240]_Lab02_Skills_and_Characteristics.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab02_Skills_and_Characteristics.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Lab 2: Skills and characteristics (20 minutes)'
-    module: 'Module 1: Configure Field Service'
+  title: 'Lab 2: Skills and characteristics (20 minutes)'
+  module: 'Module 1: Configure Field Service'
+  description: 'Each technician services and installs equipment could have several
+    different skills and roles assigned to them.  These skills and roles are used
+    by Dynamics 365 Field Service to identify resources qualified to qualified resources
+    that goes out to service customers Contoso has identified three primary roles
+    that an onsite technician might have:'
+  duration: 20 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
+  - Field Service
 ---
 
 # Practice Lab 2 - Skills and characteristics

--- a/Instructions/Labs/LAB[MB-240]_Lab03_Resource_Configuration.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab03_Resource_Configuration.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Lab 3: Creating resources (20 minutes)'
-    module: 'Module 1: Configure Field Service'
+  title: 'Lab 3: Creating resources (20 minutes)'
+  module: 'Module 1: Configure Field Service'
+  description: 'Contoso Coffee uses both internal employees as well as external contractors
+    to perform commercial installation and service existing products. Internal resources
+    are dispatched out of central locations. External resources are dispatched from
+    their location. Ou have been asked to configure Dynamics 365 Field Service to
+    support this. You must add the following:'
+  duration: 20 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
+  - Field Service
 ---
 
 # Practice Lab 3 - Creating resources

--- a/Instructions/Labs/LAB[MB-240]_Lab04_Incident_Types.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab04_Incident_Types.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Lab 4: Incident types (15 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 4: Incident types (15 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: Many of Contoso Coffees’ work orders are similar in the fact that the
+    products, services, and tasks are all the same. One that they perform often is
+    preventative maintenance on commercial coffee equipment. To improve the amount
+    of time that it takes to enter items into the system, Contoso wants to have templates
+    that can be selected when new work orders are created that will pre-populate information
+    onto a work order.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 4 - Incident types

--- a/Instructions/Labs/LAB[MB-240]_Lab05_Work_Order_Management.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab05_Work_Order_Management.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Lab 5: Work order management  (50 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 5: Work order management  (50 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: Contoso Coffee wants to make it as easy as possible for technicians
+    who are working in the field. To accomplish this, they have identified a few areas
+    that can help technicians. The first is by correctly prioritizing work orders.
+    The second is by providing technicians with predefined resolutions that they can
+    leverage when completing work orders. These resolutions will help Contoso better
+    understand how items are being resolved.
+  duration: 50 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 5 - Work order management

--- a/Instructions/Labs/LAB[MB-240]_Lab06_Agreements.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab06_Agreements.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Lab 6: Agreements (20 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 6: Agreements (20 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: Contoso Coffee provides preventative maintenance contracts on several
+    models of commercial coffee equipment that they sell. When a customer purchase
+    one of these models, Contoso will send out a technician once every three months
+    to provide preventative maintenance on a device.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 6 - Agreements

--- a/Instructions/Labs/LAB[MB-240]_Lab07_Inspections.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab07_Inspections.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 7: Inspections (15 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 7: Inspections (15 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: When Contoso’s technicians are performing preventative maintenance
+    work orders, Contoso wants to ensure that all technicians are following the same
+    inspection process. This Process ensures that nothing is missed.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 7 - Inspections

--- a/Instructions/Labs/LAB[MB-240]_Lab08_Managing_Schedules.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab08_Managing_Schedules.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Lab 8: Managing schedules (15 minutes)'
-    module: 'Module 3: Schedule and dispatch work orders'
+  title: 'Lab 8: Managing schedules (15 minutes)'
+  module: 'Module 3: Schedule and dispatch work orders'
+  description: Contoso Coffee is going to use Dynamics 365 Field Service to schedule
+    and dispatch resources to complete work orders. In this lab, you will be using
+    Dynamics 365 Field Service to schedule work orders.
+  duration: 15 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
+  - Field Service
 ---
 
 # Practice Lab 8 - Scheduling

--- a/Instructions/Labs/LAB[MB-240]_Lab09_Configure_Schedule_Board.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab09_Configure_Schedule_Board.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Lab 9: Configure Schedule Boards (10 minutes)'
-    module: 'Module 3: Schedule and dispatch work orders'
+  title: 'Lab 9: Configure Schedule Boards (10 minutes)'
+  module: 'Module 3: Schedule and dispatch work orders'
+  description: Contoso Coffee’s dispatchers are telling you that there are too many
+    resources when trying to schedule items using the schedule board. They feel like
+    it would be easier to schedule resources if the schedule boards were broken down
+    into a series of smaller boards. One way they have identified to simplify scheduling
+    is to have different boards broken down by territory.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 9 - Configure the Schedule Board

--- a/Instructions/Labs/LAB[MB-240]_Lab10_Mobile.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab10_Mobile.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Lab 10: Field Service mobile app (30 minutes)'
-    module: 'Module 4: Field Service mobile app'
+  title: 'Lab 10: Field Service mobile app (30 minutes)'
+  module: 'Module 4: Field Service mobile app'
+  description: Contoso Coffees’ onsite workers will be using the Dynamics 365 Field
+    Service mobile application to service customers. They need to ensure that they
+    can see items that are scheduled for them but can also use the application to
+    complete their work orders.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
+  - Field Service
 ---
 
 # Practice Lab 10 - Field Service mobile app

--- a/Instructions/Labs/LAB[MB-240]_Lab11_Inventory.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab11_Inventory.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 11: Inventory (10 minutes)'
-    module: 'Module 5: Inventory'
+  title: 'Lab 11: Inventory (10 minutes)'
+  module: 'Module 5: Inventory'
+  description: Contoso Coffee stores their inventory in warehouses. Once a work order
+    is ready to be delivered, inventory is transferred from a warehouse to the truck
+    that a technician will be driving to deliver the work order.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 11 - Inventory

--- a/Instructions/Labs/LAB[MB-240]_Lab12_Assets.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab12_Assets.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Lab 12: Customer assets (25 minutes)'
-    module: 'Module 6: Customer assets and connected devices'
+  title: 'Lab 12: Customer assets (25 minutes)'
+  module: 'Module 6: Customer assets and connected devices'
+  description: After a Commercial coffee machine is installed at a customer location,
+    Contoso Coffee will keep track of the assets at the customer location. This allows
+    them to track work orders that are associated with the device. You have been tasked
+    with configuring Dynamics 365 Field Service to support the use of Customer Assets.
+  duration: 25 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Dynamics 365
+  - Field Service
 ---
 
 # Practice Lab 12 - Customer assets


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 13

- `Instructions/Labs/LAB[MB-240]_Lab00_Dynamics_365_Labs.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab01_Configure_Field_Service.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab02_Skills_and_Characteristics.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab03_Resource_Configuration.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab04_Incident_Types.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab05_Work_Order_Management.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab06_Agreements.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab07_Inspections.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab08_Managing_Schedules.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab09_Configure_Schedule_Board.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab10_Mobile.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab11_Inventory.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab12_Assets.md` (description,duration,level,islab,primarytopics)
