### PR TITLE
Backfill missing lab metadata (13 files)

### DIFF
--- a/Instructions/Labs/LAB[MB-240]_Lab00_Dynamics_365_Labs.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab00_Dynamics_365_Labs.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment (5 minutes)'
-    module: 'Module 0: Course introduction'
+  title: 'Lab 0: Validate lab environment (5 minutes)'
+  module: 'Module 0: Course introduction'
+  description: You will be the primary person who will be configuring the key elements of Contoso Coffees field service deployment.
+  duration: 5 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Field Service
 ---
 
 # Practice Lab - Validate lab environment

--- a/Instructions/Labs/LAB[MB-240]_Lab01_Configure_Field_Service.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab01_Configure_Field_Service.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 1: Configure Field Service (10 minutes)'
-    module: 'Module 1: Configure Field Service'
+  title: 'Lab 1: Configure Field Service (10 minutes)'
+  module: 'Module 1: Configure Field Service'
+  description: 'Upon successful completion of this lab, you will have successfully configured the following:'
+  duration: 10 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Field Service
 ---
 
 # Practice Lab 1 - Configure Dynamics 365 Field Service

--- a/Instructions/Labs/LAB[MB-240]_Lab02_Skills_and_Characteristics.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab02_Skills_and_Characteristics.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Skills and characteristics (20 minutes)'
-    module: 'Module 1: Configure Field Service'
+  title: 'Lab 2: Skills and characteristics (20 minutes)'
+  module: 'Module 1: Configure Field Service'
+  description: In this task you will create a proficiency model that contains the five different security clearance levels and a proficiency model for skill level.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 2 - Skills and characteristics

--- a/Instructions/Labs/LAB[MB-240]_Lab03_Resource_Configuration.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab03_Resource_Configuration.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 3: Creating resources (20 minutes)'
-    module: 'Module 1: Configure Field Service'
+  title: 'Lab 3: Creating resources (20 minutes)'
+  module: 'Module 1: Configure Field Service'
+  description: In this exercise you will create the locations where internal resources will start and end their day. Each organizational unit must have a Latitude and Longitude associated with it to ensure travel times can be calculated accordingly.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 3 - Creating resources

--- a/Instructions/Labs/LAB[MB-240]_Lab04_Incident_Types.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab04_Incident_Types.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 4: Incident types (15 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 4: Incident types (15 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: Now that you Incident Type is created, In this exercise you will create a work order by using the incident type.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 4 - Incident types

--- a/Instructions/Labs/LAB[MB-240]_Lab05_Work_Order_Management.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab05_Work_Order_Management.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 5: Work order management  (50 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 5: Work order management  (50 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: In this exercise you will configure settings for work orders including priorities and resolutions.
+  duration: 50 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 5 - Work order management

--- a/Instructions/Labs/LAB[MB-240]_Lab06_Agreements.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab06_Agreements.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 6: Agreements (20 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 6: Agreements (20 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: In this exercise you will be defining a preventative maintenance agreement that will generate Work orders quarterly and bill customers every six months.
+  duration: 20 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 6 - Agreements

--- a/Instructions/Labs/LAB[MB-240]_Lab07_Inspections.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab07_Inspections.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 7: Inspections (15 minutes)'
-    module: 'Module 2: Manage Work Orders'
+  title: 'Lab 7: Inspections (15 minutes)'
+  module: 'Module 2: Manage Work Orders'
+  description: In this exercise you will be defining an inspection template, adding it to an inspection service type task, and ensuring the task is on the Preventative Maintenance incident type.
+  duration: 15 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 7 - Inspections

--- a/Instructions/Labs/LAB[MB-240]_Lab08_Managing_Schedules.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab08_Managing_Schedules.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Lab 8: Managing schedules (15 minutes)'
-    module: 'Module 3: Schedule and dispatch work orders'
+  title: 'Lab 8: Managing schedules (15 minutes)'
+  module: 'Module 3: Schedule and dispatch work orders'
+  description: Contoso Coffee is going to use Dynamics 365 Field Service to schedule and dispatch resources to complete work orders. In this lab, you will be using Dynamics 365 Field Service to schedule work orders.
+  duration: 15 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Dynamics 365
+    - Field Service
 ---
 
 # Practice Lab 8 - Scheduling

--- a/Instructions/Labs/LAB[MB-240]_Lab09_Configure_Schedule_Board.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab09_Configure_Schedule_Board.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 9: Configure Schedule Boards (10 minutes)'
-    module: 'Module 3: Schedule and dispatch work orders'
+  title: 'Lab 9: Configure Schedule Boards (10 minutes)'
+  module: 'Module 3: Schedule and dispatch work orders'
+  description: In this exercise we will create and configure a schedule board for the WA territory.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 9 - Configure the Schedule Board

--- a/Instructions/Labs/LAB[MB-240]_Lab10_Mobile.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab10_Mobile.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 10: Field Service mobile app (30 minutes)'
-    module: 'Module 4: Field Service mobile app'
+  title: 'Lab 10: Field Service mobile app (30 minutes)'
+  module: 'Module 4: Field Service mobile app'
+  description: In this exercise, you will be deploying the Field Service Mobile application to a mobile device.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Field Service
 ---
 
 # Practice Lab 10 - Field Service mobile app

--- a/Instructions/Labs/LAB[MB-240]_Lab11_Inventory.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab11_Inventory.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 11: Inventory (10 minutes)'
-    module: 'Module 5: Inventory'
+  title: 'Lab 11: Inventory (10 minutes)'
+  module: 'Module 5: Inventory'
+  description: In this exercise you will add inventory to a warehouse and then transfer it to a truck.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 11 - Inventory

--- a/Instructions/Labs/LAB[MB-240]_Lab12_Assets.md
+++ b/Instructions/Labs/LAB[MB-240]_Lab12_Assets.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 12: Customer assets (25 minutes)'
-    module: 'Module 6: Customer assets and connected devices'
+  title: 'Lab 12: Customer assets (25 minutes)'
+  module: 'Module 6: Customer assets and connected devices'
+  description: In this exercise you will create the assets for a customer.
+  duration: 25 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 12 - Customer assets


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 13

- `Instructions/Labs/LAB[MB-240]_Lab00_Dynamics_365_Labs.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab01_Configure_Field_Service.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab02_Skills_and_Characteristics.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab03_Resource_Configuration.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab04_Incident_Types.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab05_Work_Order_Management.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab06_Agreements.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab07_Inspections.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab08_Managing_Schedules.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab09_Configure_Schedule_Board.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab10_Mobile.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB[MB-240]_Lab11_Inventory.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[MB-240]_Lab12_Assets.md` (description,duration,level,islab)
